### PR TITLE
fetch token from oauth2 server as a background process / just change port for http to 8080

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -1,23 +1,26 @@
 package server
 
 import (
+	"github.com/dpattmann/furby/internal/auth"
+	"github.com/dpattmann/furby/internal/store"
+
 	"encoding/json"
 	"log"
 	"net/http"
-
-	"github.com/dpattmann/furby/internal/auth"
-	"github.com/dpattmann/furby/internal/store"
+	"sync"
 )
 
 type Handler struct {
-	store store.Store
-	auth  auth.Authorizer
+	store     store.Store
+	auth      auth.Authorizer
+	waitGroup *sync.WaitGroup
 }
 
-func NewHandler(store store.Store, auth auth.Authorizer) Handler {
+func NewHandler(store store.Store, auth auth.Authorizer, wg *sync.WaitGroup) Handler {
 	return Handler{
-		store: store,
-		auth:  auth,
+		store:     store,
+		auth:      auth,
+		waitGroup: wg,
 	}
 }
 
@@ -42,6 +45,8 @@ func (t Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	jsonToken, err := json.Marshal(token)
 
 	t.writeTokenResponse(w, http.StatusOK, jsonToken)
+
+	t.waitGroup.Wait()
 
 	return
 }

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/dpattmann/furby/mocks"
@@ -16,6 +17,7 @@ import (
 
 var (
 	mockToken = oauth2.Token{AccessToken: "foo"}
+	wg        sync.WaitGroup
 )
 
 func setupMock(storeToken *oauth2.Token, storeError error, authReturn bool) (mockStore *mocks.Store, mockAuth *mocks.Authorization) {
@@ -35,7 +37,7 @@ func Test_StoreHandler(t *testing.T) {
 		mockStore, mockAuth := setupMock(&mockToken, nil, true)
 
 		// create Handler with mocked store and auth
-		storeHandler := NewHandler(mockStore, mockAuth)
+		storeHandler := NewHandler(mockStore, mockAuth, &wg)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		responseRecorder := httptest.NewRecorder()
@@ -59,7 +61,7 @@ func Test_StoreHandler(t *testing.T) {
 		mockStore, mockAuth := setupMock(nil, errors.New("no token found"), true)
 
 		// create Handler with mocked store and auth
-		storeHandler := NewHandler(mockStore, mockAuth)
+		storeHandler := NewHandler(mockStore, mockAuth, &wg)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		responseRecorder := httptest.NewRecorder()
@@ -78,7 +80,7 @@ func Test_StoreHandler(t *testing.T) {
 		mockStore, mockAuth := setupMock(&mockToken, nil, false)
 
 		// create Handler with mocked store and auth
-		storeHandler := NewHandler(mockStore, mockAuth)
+		storeHandler := NewHandler(mockStore, mockAuth, &wg)
 
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		responseRecorder := httptest.NewRecorder()
@@ -97,7 +99,7 @@ func Test_StoreHandler(t *testing.T) {
 		mockStore, mockAuth := setupMock(nil, nil, true)
 
 		// create Handler with mocked store and auth
-		storeHandler := NewHandler(mockStore, mockAuth)
+		storeHandler := NewHandler(mockStore, mockAuth, &wg)
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
 		responseRecorder := httptest.NewRecorder()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,8 @@
 package store
 
-import "golang.org/x/oauth2"
+import (
+	"golang.org/x/oauth2"
+)
 
 type Store interface {
 	GetToken() (*oauth2.Token, error)


### PR DESCRIPTION
This is feature to be discussed. The idea: fetch a token from oauth2 server directly only for the very first time. After that fetch a token in a background as goroutine shortly before the token gets expired. While fetching we can still return the saved token, because it's still valid. On this way we would return a valid token for all the time (except at a very first time) directly from cache and save time wasted for handling tcp/ip stack. 

The value of prefetchTime was set to 3590 only to test purpose. The Token in docker-compose environment is valid for 1 hour (3600 sec.) and would be refetched after 10 sec. For future we could define it as a parameter setting by user or we could calculate it depending on expiration of token. 